### PR TITLE
chore(broker): remove partially added license headers

### DIFF
--- a/broker/spring-zeebe-broker/src/main/java/io/zeebe/spring/broker/EnableZeebeBroker.java
+++ b/broker/spring-zeebe-broker/src/main/java/io/zeebe/spring/broker/EnableZeebeBroker.java
@@ -1,18 +1,3 @@
-/*
- * Copyright © 2017 camunda services GmbH (info@camunda.com)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.zeebe.spring.broker;
 
 import io.zeebe.spring.broker.config.ZeebeBrokerConfiguration;

--- a/broker/spring-zeebe-broker/src/main/java/io/zeebe/spring/broker/config/SpringZeebeBroker.java
+++ b/broker/spring-zeebe-broker/src/main/java/io/zeebe/spring/broker/config/SpringZeebeBroker.java
@@ -1,18 +1,3 @@
-/*
- * Copyright © 2017 camunda services GmbH (info@camunda.com)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.zeebe.spring.broker.config;
 
 import io.zeebe.broker.Broker;

--- a/broker/spring-zeebe-broker/src/main/java/io/zeebe/spring/broker/config/ZeebeBrokerConfiguration.java
+++ b/broker/spring-zeebe-broker/src/main/java/io/zeebe/spring/broker/config/ZeebeBrokerConfiguration.java
@@ -1,18 +1,3 @@
-/*
- * Copyright © 2017 camunda services GmbH (info@camunda.com)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.zeebe.spring.broker.config;
 
 import io.zeebe.broker.system.ConfigurationManager;

--- a/broker/spring-zeebe-broker/src/test/java/io/zeebe/spring/broker/config/ZeebeBrokerConfigurationTest.java
+++ b/broker/spring-zeebe-broker/src/test/java/io/zeebe/spring/broker/config/ZeebeBrokerConfigurationTest.java
@@ -1,18 +1,3 @@
-/*
- * Copyright © 2017 camunda services GmbH (info@camunda.com)
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
 package io.zeebe.spring.broker.config;
 
 import org.junit.Test;


### PR DESCRIPTION
- with commit abfa1e6 a camunda license
  header was added to some files
- remove the license header
- since bc88f69 the license header will
  not be added anymore by maven