### PR TITLE
Update Spring Boot to version 2.1.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,11 @@ buildNumber.properties
 
 # osx ignores
 .DS_Store
+vscode_workspace.code-workspace
+
+#VSCODE: subprojects settings directory
+**/.settings
+#VSCODE: files
+*.project
+*.classpath
+*.factorypath

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ vscode_workspace.code-workspace
 *.project
 *.classpath
 *.factorypath
+.vscode/launch.json

--- a/pom.xml
+++ b/pom.xml
@@ -23,8 +23,9 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
 
+
     <zeebe.version>0.17.0</zeebe.version>
-    <spring-boot.version>2.0.4.RELEASE</spring-boot.version>
+    <spring-boot.version>2.1.4.RELEASE</spring-boot.version>
 
     <!-- release parent settings for distribution management -->
     <nexus.snapshot.repository>


### PR DESCRIPTION
This pull request updates Zeebe Client API support to version 0.16.4 as requested by some users. It also updates Spring Boot version to 2.1.4RELEASE.