### PR TITLE
Application.yml correctly used by spring-zeebe-starter

### DIFF
--- a/client/spring-zeebe-starter/src/main/java/io/zeebe/spring/client/config/ZeebeClientStarterAutoConfiguration.java
+++ b/client/spring-zeebe-starter/src/main/java/io/zeebe/spring/client/config/ZeebeClientStarterAutoConfiguration.java
@@ -4,6 +4,7 @@ import io.zeebe.client.ZeebeClientBuilder;
 import io.zeebe.client.impl.ZeebeClientBuilderImpl;
 import io.zeebe.spring.client.properties.ZeebeClientConfigurationProperties;
 import lombok.RequiredArgsConstructor;
+
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -15,12 +16,19 @@ import org.springframework.context.annotation.Primary;
 public class ZeebeClientStarterAutoConfiguration {
 
   private final ZeebeClientConfigurationProperties configurationProperties;
-
+  
   @Bean
   @Primary
   public ZeebeClientBuilder builder() {
     final ZeebeClientBuilderImpl builder = new ZeebeClientBuilderImpl();
 
+    builder.brokerContactPoint(configurationProperties.getBrokerContactPoint());
+    builder.defaultJobPollInterval(configurationProperties.getDefaultJobPollInterval());
+    builder.defaultJobTimeout(configurationProperties.getDefaultJobTimeout());
+    builder.defaultJobWorkerMaxJobsActive(configurationProperties.getDefaultJobWorkerMaxJobsActive());
+    builder.defaultJobWorkerName(configurationProperties.getDefaultJobWorkerName());
+    builder.defaultMessageTimeToLive(configurationProperties.getDefaultMessageTimeToLive());
+    
     return builder;
   }
 }

--- a/client/spring-zeebe-starter/src/test/java/io/zeebe/spring/client/properties/ZeebeClientSpringConfigurationDefaultPropertiesTest.java
+++ b/client/spring-zeebe-starter/src/test/java/io/zeebe/spring/client/properties/ZeebeClientSpringConfigurationDefaultPropertiesTest.java
@@ -54,4 +54,9 @@ public class ZeebeClientSpringConfigurationDefaultPropertiesTest {
   public void hasWorkerThreads() throws Exception {
     assertThat(properties.getWorker().getThreads()).isEqualTo(1);
   }
+
+  @Test
+  public void hasMessageTimeToLeave() throws Exception {
+    assertThat(properties.getMessage().getTimeToLive()).isEqualTo(Duration.ofSeconds(3600));
+  }
 }

--- a/client/spring-zeebe-starter/src/test/java/io/zeebe/spring/client/properties/ZeebeClientSpringConfigurationDefaultPropertiesTest.java
+++ b/client/spring-zeebe-starter/src/test/java/io/zeebe/spring/client/properties/ZeebeClientSpringConfigurationDefaultPropertiesTest.java
@@ -1,0 +1,57 @@
+package io.zeebe.spring.client.properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@ContextConfiguration(classes = ZeebeClientSpringConfigurationDefaultPropertiesTest.TestConfig.class)
+public class ZeebeClientSpringConfigurationDefaultPropertiesTest {
+
+  @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
+  public static class TestConfig {
+
+  }
+
+  @Autowired
+  private ZeebeClientConfigurationProperties properties;
+
+  @Test
+  public void hasBrokerContactPoint() throws Exception {
+    assertThat(properties.getBrokerContactPoint()).isEqualTo("0.0.0.0:26500");
+  }
+
+  @Test
+  public void hasWorkerName() throws Exception {
+    assertThat(properties.getWorker().getName()).isEqualTo("default");
+
+  }
+
+  @Test
+  public void hasWorkerTimeout() throws Exception {
+    assertThat(properties.getWorker().getTimeout()).isEqualTo(Duration.ofSeconds(300));
+  }
+
+  @Test
+  public void hasWorkerMaxJobsActive() throws Exception {
+    assertThat(properties.getWorker().getMaxJobsActive()).isEqualTo(32);
+
+  }
+
+  @Test
+  public void hasWorkerPollInterval() throws Exception {
+    assertThat(properties.getWorker().getPollInterval()).isEqualTo(Duration.ofNanos(100000000));
+  }
+
+  @Test
+  public void hasWorkerThreads() throws Exception {
+    assertThat(properties.getWorker().getThreads()).isEqualTo(1);
+  }
+}

--- a/client/spring-zeebe-starter/src/test/java/io/zeebe/spring/client/properties/ZeebeClientSpringConfigurationPropertiesTest.java
+++ b/client/spring-zeebe-starter/src/test/java/io/zeebe/spring/client/properties/ZeebeClientSpringConfigurationPropertiesTest.java
@@ -2,6 +2,8 @@ package io.zeebe.spring.client.properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.time.Duration;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -11,7 +13,16 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.junit4.SpringRunner;
 
 @RunWith(SpringRunner.class)
-@TestPropertySource(properties = {"zeebe.client.broker.contactPoint=localhost12345"})
+@TestPropertySource(
+  properties = {
+    "zeebe.client.broker.contactPoint=localhost12345",
+    "zeebe.client.worker.name=testName",
+    "zeebe.client.worker.timeout=99s",
+    "zeebe.client.worker.maxJobsActive=99",
+    "zeebe.client.worker.pollInterval=99s",
+    "zeebe.client.worker.threads=99"
+  }
+)
 @ContextConfiguration(classes = ZeebeClientSpringConfigurationPropertiesTest.TestConfig.class)
 public class ZeebeClientSpringConfigurationPropertiesTest {
 
@@ -26,5 +37,32 @@ public class ZeebeClientSpringConfigurationPropertiesTest {
   @Test
   public void hasBrokerContactPoint() throws Exception {
     assertThat(properties.getBrokerContactPoint()).isEqualTo("localhost12345");
+  }
+
+  @Test
+  public void hasWorkerName() throws Exception {
+    assertThat(properties.getWorker().getName()).isEqualTo("testName");
+
+  }
+
+  @Test
+  public void hasWorkerTimeout() throws Exception {
+    assertThat(properties.getWorker().getTimeout()).isEqualTo(Duration.ofSeconds(99));
+  }
+
+  @Test
+  public void hasWorkerMaxJobsActive() throws Exception {
+    assertThat(properties.getWorker().getMaxJobsActive()).isEqualTo(99);
+
+  }
+
+  @Test
+  public void hasWorkerPollInterval() throws Exception {
+    assertThat(properties.getWorker().getPollInterval()).isEqualTo(Duration.ofSeconds(99));
+  }
+
+  @Test
+  public void hasWorkerThreads() throws Exception {
+    assertThat(properties.getWorker().getThreads()).isEqualTo(99);
   }
 }

--- a/client/spring-zeebe-starter/src/test/java/io/zeebe/spring/client/properties/ZeebeClientSpringConfigurationPropertiesTest.java
+++ b/client/spring-zeebe-starter/src/test/java/io/zeebe/spring/client/properties/ZeebeClientSpringConfigurationPropertiesTest.java
@@ -20,7 +20,8 @@ import org.springframework.test.context.junit4.SpringRunner;
     "zeebe.client.worker.timeout=99s",
     "zeebe.client.worker.maxJobsActive=99",
     "zeebe.client.worker.pollInterval=99s",
-    "zeebe.client.worker.threads=99"
+    "zeebe.client.worker.threads=99",
+    "zeebe.client.message.timeToLive=99s"
   }
 )
 @ContextConfiguration(classes = ZeebeClientSpringConfigurationPropertiesTest.TestConfig.class)
@@ -64,5 +65,10 @@ public class ZeebeClientSpringConfigurationPropertiesTest {
   @Test
   public void hasWorkerThreads() throws Exception {
     assertThat(properties.getWorker().getThreads()).isEqualTo(99);
+  }
+
+  @Test
+  public void hasMessageTimeToLeave() throws Exception {
+    assertThat(properties.getMessage().getTimeToLive()).isEqualTo(Duration.ofSeconds(99));
   }
 }

--- a/client/spring-zeebe/src/main/java/io/zeebe/spring/client/config/ZeebeClientSpringConfiguration.java
+++ b/client/spring-zeebe/src/main/java/io/zeebe/spring/client/config/ZeebeClientSpringConfiguration.java
@@ -1,5 +1,6 @@
 package io.zeebe.spring.client.config;
 
+import io.zeebe.client.ZeebeClientBuilder;
 import io.zeebe.client.impl.ZeebeClientBuilderImpl;
 import io.zeebe.client.impl.ZeebeClientImpl;
 import io.zeebe.spring.client.ZeebeClientLifecycle;
@@ -7,6 +8,8 @@ import io.zeebe.spring.client.ZeebeClientObjectFactory;
 import io.zeebe.spring.client.bean.value.factory.ReadAnnotationValueConfiguration;
 import io.zeebe.spring.client.config.processor.PostProcessorConfiguration;
 import java.util.Properties;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
@@ -14,8 +17,12 @@ import org.springframework.context.annotation.Import;
 @Import({
   PostProcessorConfiguration.class,
   ReadAnnotationValueConfiguration.class,
+
 })
 public class ZeebeClientSpringConfiguration {
+
+  @Autowired
+  ZeebeClientBuilder zeebeClientBuilder;
 
   public static final ZeebeClientBuilderImpl DEFAULT =
     (ZeebeClientBuilderImpl) new ZeebeClientBuilderImpl().withProperties(new Properties());
@@ -29,6 +36,6 @@ public class ZeebeClientSpringConfiguration {
 
   @Bean
   public ZeebeClientObjectFactory zeebeClientObjectFactory() {
-    return () -> (ZeebeClientImpl) DEFAULT.build();
+    return () -> (ZeebeClientImpl) zeebeClientBuilder.build();
   }
 }

--- a/examples/starter/src/main/resources/application.yaml
+++ b/examples/starter/src/main/resources/application.yaml
@@ -1,3 +1,4 @@
 zeebe:
-  broker:
-    contactPoint: "127.0.0.1:26500"
+  client:
+    broker:
+      contactPoint: "127.0.0.1:26500"


### PR DESCRIPTION
This hopefully close #49 . 

Please @menski and @jangalinski review carefully because a better way to implement this fix should easily exist (due to my low knowledge of spring).

IMHO what's needed: 

- [x] test to check the yaml has been correctly fetched if present (i.e. default values).

- [x] more tests for other client - worker properties

. Opened to your feedback!