### PR TITLE
Support Zeebe 0.21, Spring 2.2.0 and Java 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,4 +29,5 @@ vscode_workspace.code-workspace
 *.project
 *.classpath
 *.factorypath
-.vscode/launch.json
+.vscode/*
+.attach_pid*

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 sudo: false # faster builds
 
 jdk:
-- oraclejdk8
+- oraclejdk11
 
 install: true
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: java
 sudo: false # faster builds
 
 jdk:
-- oraclejdk11
+- openjdk11
 
 install: true
 cache:

--- a/broker/spring-zeebe-broker/pom.xml
+++ b/broker/spring-zeebe-broker/pom.xml
@@ -18,7 +18,7 @@
     </dependency>
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zeebe-broker-core</artifactId>
+      <artifactId>zeebe-broker</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/client/spring-zeebe-starter/src/main/java/io/zeebe/spring/client/config/ZeebeClientStarterAutoConfiguration.java
+++ b/client/spring-zeebe-starter/src/main/java/io/zeebe/spring/client/config/ZeebeClientStarterAutoConfiguration.java
@@ -1,14 +1,14 @@
 package io.zeebe.spring.client.config;
 
-import io.zeebe.client.ZeebeClientBuilder;
-import io.zeebe.client.impl.ZeebeClientBuilderImpl;
-import io.zeebe.spring.client.properties.ZeebeClientConfigurationProperties;
-import lombok.RequiredArgsConstructor;
-
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
+
+import io.zeebe.client.ZeebeClientBuilder;
+import io.zeebe.client.impl.ZeebeClientBuilderImpl;
+import io.zeebe.spring.client.properties.ZeebeClientConfigurationProperties;
+import lombok.RequiredArgsConstructor;
 
 @EnableConfigurationProperties(ZeebeClientConfigurationProperties.class)
 @Configuration
@@ -28,6 +28,10 @@ public class ZeebeClientStarterAutoConfiguration {
     builder.defaultJobWorkerMaxJobsActive(configurationProperties.getDefaultJobWorkerMaxJobsActive());
     builder.defaultJobWorkerName(configurationProperties.getDefaultJobWorkerName());
     builder.defaultMessageTimeToLive(configurationProperties.getDefaultMessageTimeToLive());
+    builder.defaultRequestTimeout(configurationProperties.getDefaultRequestTimeout());
+    builder.caCertificatePath(configurationProperties.getCaCertificatePath());
+    if (configurationProperties.isPlaintextConnectionEnabled())
+      builder.usePlaintext();
     
     return builder;
   }

--- a/client/spring-zeebe-starter/src/main/java/io/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
+++ b/client/spring-zeebe-starter/src/main/java/io/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
@@ -3,9 +3,12 @@ package io.zeebe.spring.client.properties;
 import static io.zeebe.spring.client.config.ZeebeClientSpringConfiguration.DEFAULT;
 
 import java.time.Duration;
-import lombok.Data;
+
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.NestedConfigurationProperty;
+
+import io.zeebe.client.CredentialsProvider;
+import lombok.Data;
 
 @Data
 @ConfigurationProperties(prefix = "zeebe.client")
@@ -20,25 +23,41 @@ public class ZeebeClientConfigurationProperties implements ZeebeClientProperties
   @NestedConfigurationProperty
   private Message message = new Message();
 
+  @NestedConfigurationProperty
+  private Security security = new Security();
+
+  @NestedConfigurationProperty
+  private Job job = new Job();
+
+  private Duration requestTimeout = DEFAULT.getDefaultRequestTimeout();
+
   @Data
   public static class Broker {
-
     private String contactPoint = DEFAULT.getBrokerContactPoint();
-    private Duration requestTimeout = DEFAULT.getDefaultRequestTimeout();
   }
 
   @Data
   public static class Worker {
-    private String name = DEFAULT.getDefaultJobWorkerName();
-    private Duration timeout = DEFAULT.getDefaultJobTimeout();
     private Integer maxJobsActive = DEFAULT.getDefaultJobWorkerMaxJobsActive();
-    private Duration pollInterval = DEFAULT.getDefaultJobPollInterval();
     private Integer threads = DEFAULT.getNumJobWorkerExecutionThreads();
+  }
+
+  @Data
+  public static class Job {
+    private String worker = DEFAULT.getDefaultJobWorkerName();
+    private Duration timeout = DEFAULT.getDefaultJobTimeout();
+    private Duration pollInterval = DEFAULT.getDefaultJobPollInterval();
   }
 
   @Data
   public static class Message {
     private Duration timeToLive = DEFAULT.getDefaultMessageTimeToLive();
+  }
+
+  @Data
+  public static class Security{
+    private boolean plaintext = DEFAULT.isPlaintextConnectionEnabled();
+    private String certPath = DEFAULT.getCaCertificatePath();
   }
 
   @Override
@@ -48,7 +67,7 @@ public class ZeebeClientConfigurationProperties implements ZeebeClientProperties
 
   @Override
   public Duration getDefaultRequestTimeout() {
-    return broker.getRequestTimeout();
+    return getRequestTimeout();
   }
 
   @Override
@@ -63,22 +82,37 @@ public class ZeebeClientConfigurationProperties implements ZeebeClientProperties
 
   @Override
   public String getDefaultJobWorkerName() {
-    return worker.getName();
+    return job.getWorker();
   }
 
   @Override
   public Duration getDefaultJobTimeout() {
-    return worker.getTimeout();
+    return job.getTimeout();
   }
 
   @Override
   public Duration getDefaultJobPollInterval() {
-    return worker.getPollInterval();
+    return job.getPollInterval();
   }
 
   @Override
   public Duration getDefaultMessageTimeToLive() {
     return message.getTimeToLive();
+  }
+
+  @Override
+  public boolean isPlaintextConnectionEnabled() {
+    return security.isPlaintext();
+  }
+
+  @Override
+  public String getCaCertificatePath() {
+    return security.getCertPath();
+  }
+
+  @Override
+  public CredentialsProvider getCredentialsProvider() {
+    return null;
   }
   
 }

--- a/client/spring-zeebe-starter/src/test/java/io/zeebe/spring/client/properties/ZeebeClientSpringConfigurationDefaultPropertiesTest.java
+++ b/client/spring-zeebe-starter/src/test/java/io/zeebe/spring/client/properties/ZeebeClientSpringConfigurationDefaultPropertiesTest.java
@@ -29,40 +29,50 @@ public class ZeebeClientSpringConfigurationDefaultPropertiesTest {
   }
 
   @Test
-  public void hasBrokerRequestTimeout() throws Exception {
-    assertThat(properties.getBroker().getRequestTimeout()).isEqualTo(Duration.ofSeconds(20));
+  public void hasRequestTimeout() throws Exception {
+    assertThat(properties.getRequestTimeout()).isEqualTo(Duration.ofSeconds(20));
   }
 
   @Test
   public void hasWorkerName() throws Exception {
-    assertThat(properties.getWorker().getName()).isEqualTo("default");
+    assertThat(properties.getDefaultJobWorkerName()).isEqualTo("default");
 
   }
 
   @Test
-  public void hasWorkerTimeout() throws Exception {
-    assertThat(properties.getWorker().getTimeout()).isEqualTo(Duration.ofSeconds(300));
+  public void hasJobTimeout() throws Exception {
+    assertThat(properties.getDefaultJobTimeout()).isEqualTo(Duration.ofSeconds(300));
   }
 
   @Test
   public void hasWorkerMaxJobsActive() throws Exception {
-    assertThat(properties.getWorker().getMaxJobsActive()).isEqualTo(32);
+    assertThat(properties.getDefaultJobWorkerMaxJobsActive()).isEqualTo(32);
 
   }
 
   @Test
-  public void hasWorkerPollInterval() throws Exception {
-    assertThat(properties.getWorker().getPollInterval()).isEqualTo(Duration.ofNanos(100000000));
+  public void hasJobPollInterval() throws Exception {
+    assertThat(properties.getDefaultJobPollInterval()).isEqualTo(Duration.ofNanos(100000000));
   }
 
   @Test
   public void hasWorkerThreads() throws Exception {
-    assertThat(properties.getWorker().getThreads()).isEqualTo(1);
+    assertThat(properties.getNumJobWorkerExecutionThreads()).isEqualTo(1);
+  }
+
+  @Test 
+  public void hasMessageTimeToLeave() throws Exception {
+    assertThat(properties.getDefaultMessageTimeToLive()).isEqualTo(Duration.ofSeconds(3600));
   }
 
   @Test
-  public void hasMessageTimeToLeave() throws Exception {
-    assertThat(properties.getMessage().getTimeToLive()).isEqualTo(Duration.ofSeconds(3600));
+  public void isSecurityPlainTextDisabled() throws Exception {
+    assertThat(properties.isPlaintextConnectionEnabled()).isFalse();
+  }
+
+  @Test
+  public void hasSecurityCertificatePath() throws Exception {
+    assertThat(properties.getCaCertificatePath()).isNull();
   }
 
 }

--- a/client/spring-zeebe-starter/src/test/java/io/zeebe/spring/client/properties/ZeebeClientSpringConfigurationPropertiesTest.java
+++ b/client/spring-zeebe-starter/src/test/java/io/zeebe/spring/client/properties/ZeebeClientSpringConfigurationPropertiesTest.java
@@ -16,14 +16,15 @@ import org.springframework.test.context.junit4.SpringRunner;
 @TestPropertySource(
   properties = {
     "zeebe.client.broker.contactPoint=localhost12345",
-    "zeebe.client.broker.requestTimeout=99s",
-    "zeebe.client.worker.name=testName",
-    "zeebe.client.worker.timeout=99s",
+    "zeebe.client.requestTimeout=99s",
+    "zeebe.client.job.worker=testName",
+    "zeebe.client.job.timeout=99s",
+    "zeebe.client.job.pollInterval=99s",
     "zeebe.client.worker.maxJobsActive=99",
-    "zeebe.client.worker.pollInterval=99s",
     "zeebe.client.worker.threads=99",
     "zeebe.client.message.timeToLive=99s",
-    
+    "zeebe.client.security.certpath=aPath",
+    "zeebe.client.security.plaintext=true"
   }
 )
 @ContextConfiguration(classes = ZeebeClientSpringConfigurationPropertiesTest.TestConfig.class)
@@ -43,19 +44,18 @@ public class ZeebeClientSpringConfigurationPropertiesTest {
   }
 
   @Test
-  public void hasBrokerRequestTimeout() throws Exception {
-    assertThat(properties.getBroker().getRequestTimeout()).isEqualTo(Duration.ofSeconds(99));
+  public void hasRequestTimeout() throws Exception {
+    assertThat(properties.getRequestTimeout()).isEqualTo(Duration.ofSeconds(99));
   }
 
   @Test
   public void hasWorkerName() throws Exception {
-    assertThat(properties.getWorker().getName()).isEqualTo("testName");
-
+    assertThat(properties.getDefaultJobWorkerName()).isEqualTo("testName");
   }
 
   @Test
-  public void hasWorkerTimeout() throws Exception {
-    assertThat(properties.getWorker().getTimeout()).isEqualTo(Duration.ofSeconds(99));
+  public void hasJobTimeout() throws Exception {
+    assertThat(properties.getJob().getTimeout()).isEqualTo(Duration.ofSeconds(99));
   }
 
   @Test
@@ -65,8 +65,8 @@ public class ZeebeClientSpringConfigurationPropertiesTest {
   }
 
   @Test
-  public void hasWorkerPollInterval() throws Exception {
-    assertThat(properties.getWorker().getPollInterval()).isEqualTo(Duration.ofSeconds(99));
+  public void hasJobPollInterval() throws Exception {
+    assertThat(properties.getJob().getPollInterval()).isEqualTo(Duration.ofSeconds(99));
   }
 
   @Test
@@ -77,6 +77,16 @@ public class ZeebeClientSpringConfigurationPropertiesTest {
   @Test
   public void hasMessageTimeToLeave() throws Exception {
     assertThat(properties.getMessage().getTimeToLive()).isEqualTo(Duration.ofSeconds(99));
+  }
+
+  @Test
+  public void isSecurityPlainTextDisabled() throws Exception {
+    assertThat(properties.getSecurity().isPlaintext()).isTrue();
+  }
+
+  @Test
+  public void hasSecurityCertificatePath() throws Exception {
+    assertThat(properties.getSecurity().getCertPath()).isEqualTo("aPath");
   }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 
 
     <zeebe.version>0.21.1</zeebe.version>
-    <spring-boot.version>2.1.7.RELEASE</spring-boot.version>
+    <spring-boot.version>2.2.0.RELEASE</spring-boot.version>
 
     <!-- release parent settings for distribution management -->
     <nexus.snapshot.repository>
@@ -142,13 +142,6 @@
           <configuration>
             <release>${java.version}</release>
           </configuration>
-          <dependencies>
-            <dependency>
-              <groupId>org.ow2.asm</groupId>
-              <artifactId>asm</artifactId>
-              <version>6.2</version>
-            </dependency>
-          </dependencies>
         </plugin>
         <plugin>
           <artifactId>kotlin-maven-plugin</artifactId>
@@ -199,13 +192,6 @@
           <source>${java.version}</source>
           <target>${java.version}</target>
         </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>org.ow2.asm</groupId>
-            <artifactId>asm</artifactId>
-            <version>6.2</version>
-          </dependency>
-        </dependencies>
         <executions>
           <!-- Replacing default-compile as it is treated specially by maven -->
           <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -17,15 +17,15 @@
 
   <properties>
     <project.build.resourceEncoding>${project.build.sourceEncoding}</project.build.resourceEncoding>
-    <version.java>1.8</version.java>
+    <version.java>11</version.java>
     <java.version>${version.java}</java.version>
 
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
 
 
-    <zeebe.version>0.20.0</zeebe.version>
-    <spring-boot.version>2.1.4.RELEASE</spring-boot.version>
+    <zeebe.version>0.21.1</zeebe.version>
+    <spring-boot.version>2.1.7.RELEASE</spring-boot.version>
 
     <!-- release parent settings for distribution management -->
     <nexus.snapshot.repository>
@@ -139,6 +139,16 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.8.0</version>
+          <configuration>
+            <release>${java.version}</release>
+          </configuration>
+          <dependencies>
+            <dependency>
+              <groupId>org.ow2.asm</groupId>
+              <artifactId>asm</artifactId>
+              <version>6.2</version>
+            </dependency>
+          </dependencies>
         </plugin>
         <plugin>
           <artifactId>kotlin-maven-plugin</artifactId>
@@ -189,6 +199,13 @@
           <source>${java.version}</source>
           <target>${java.version}</target>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+            <version>6.2</version>
+          </dependency>
+        </dependencies>
         <executions>
           <!-- Replacing default-compile as it is treated specially by maven -->
           <execution>
@@ -219,7 +236,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.7.9</version>
+        <version>0.8.5</version>
         <executions>
           <execution>
             <goals>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -31,7 +31,7 @@
 
     <dependency>
       <groupId>io.zeebe</groupId>
-      <artifactId>zeebe-broker-core</artifactId>
+      <artifactId>zeebe-broker</artifactId>
     </dependency>
 
     <dependency>
@@ -47,6 +47,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <version>2.20.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>

--- a/test/pom.xml
+++ b/test/pom.xml
@@ -47,7 +47,6 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
-      <version>2.20.0</version>
       <scope>compile</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Tested with Oracle jdk 11. Tests runs fine.

Maintainers please check:

- Pom changes to support Java 11 (I did several checks on the net to upgrade some plugins and dependencies
- Broker changes: I added new properties introduced in 0.21 java client. Please notify me in case of other functionalities I may have not covered with this PR that can impact spring-zeebe
Issues: this PR is subjected to issue #67 . **Please do not merge until the issue has been closed** (reply from Java Client maintainers needed).