### PR TITLE
Deployment of multiple resources by annotation

### DIFF
--- a/client/spring-zeebe/src/main/java/io/zeebe/spring/client/annotation/ZeebeDeployment.java
+++ b/client/spring-zeebe/src/main/java/io/zeebe/spring/client/annotation/ZeebeDeployment.java
@@ -12,5 +12,5 @@ import java.lang.annotation.Target;
 @Documented
 @Inherited // has to be inherited to work on spring aop beans
 public @interface ZeebeDeployment {
-  String classPathResource();
+  String[] classPathResources();
 }

--- a/client/spring-zeebe/src/main/java/io/zeebe/spring/client/bean/value/ZeebeDeploymentValue.java
+++ b/client/spring-zeebe/src/main/java/io/zeebe/spring/client/bean/value/ZeebeDeploymentValue.java
@@ -4,11 +4,13 @@ import io.zeebe.spring.client.bean.ClassInfo;
 import lombok.Builder;
 import lombok.Value;
 
+import java.util.List;
+
 @Value
 @Builder
 public class ZeebeDeploymentValue implements ZeebeAnnotationValue<ClassInfo> {
 
-  private String classPathResource;
+  private List<String> classPathResources;
 
   private ClassInfo beanInfo;
 }

--- a/client/spring-zeebe/src/main/java/io/zeebe/spring/client/bean/value/factory/ReadZeebeDeploymentValue.java
+++ b/client/spring-zeebe/src/main/java/io/zeebe/spring/client/bean/value/factory/ReadZeebeDeploymentValue.java
@@ -4,7 +4,11 @@ import io.zeebe.spring.client.annotation.ZeebeDeployment;
 import io.zeebe.spring.client.bean.ClassInfo;
 import io.zeebe.spring.client.bean.value.ZeebeDeploymentValue;
 import io.zeebe.spring.util.ZeebeExpressionResolver;
+
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 public class ReadZeebeDeploymentValue
   extends ReadAnnotationValue<ClassInfo, ZeebeDeployment, ZeebeDeploymentValue> {
@@ -21,7 +25,15 @@ public class ReadZeebeDeploymentValue
         annotation ->
           ZeebeDeploymentValue.builder()
             .beanInfo(classInfo)
-            .classPathResource(resolver.resolve(annotation.classPathResource()))
+            .classPathResources(
+              resolveResources(annotation.classPathResources())
+            )
             .build());
+  }
+
+  private List<String> resolveResources(String[] classPathResources) {
+    return Arrays.stream(classPathResources)
+      .map(resource -> ((String) resolver.resolve(resource)))
+      .collect(Collectors.toList());
   }
 }

--- a/client/spring-zeebe/src/main/java/io/zeebe/spring/client/config/processor/DeploymentPostProcessor.java
+++ b/client/spring-zeebe/src/main/java/io/zeebe/spring/client/config/processor/DeploymentPostProcessor.java
@@ -1,6 +1,7 @@
 package io.zeebe.spring.client.config.processor;
 
 import io.zeebe.client.ZeebeClient;
+import io.zeebe.client.api.command.DeployWorkflowCommandStep1;
 import io.zeebe.client.api.response.DeploymentEvent;
 import io.zeebe.spring.client.annotation.ZeebeDeployment;
 import io.zeebe.spring.client.bean.ClassInfo;
@@ -29,9 +30,15 @@ public class DeploymentPostProcessor extends BeanInfoPostProcessor {
     log.info("deployment: {}", value);
 
     return client -> {
-      final DeploymentEvent deploymentResult = client
-        .newDeployCommand()
-        .addResourceFromClasspath(value.getClassPathResource())
+
+      DeployWorkflowCommandStep1 deployWorkflowCommand = client
+        .newDeployCommand();
+
+      DeploymentEvent deploymentResult = value.getClassPathResources()
+        .stream()
+        .map(deployWorkflowCommand::addResourceFromClasspath)
+        .reduce((first, second) -> second)
+        .orElseThrow(() -> new IllegalArgumentException("Requires at least one resource to deploy"))
         .send()
         .join();
 

--- a/client/spring-zeebe/src/test/java/io/zeebe/spring/client/bean/ClassInfoTest.java
+++ b/client/spring-zeebe/src/test/java/io/zeebe/spring/client/bean/ClassInfoTest.java
@@ -9,7 +9,7 @@ import org.junit.Test;
 
 public class ClassInfoTest {
 
-  @ZeebeDeployment(classPathResource = "/1.bpmn")
+  @ZeebeDeployment(classPathResources = "/1.bpmn")
   public static class WithDeploymentAnnotation {
 
   }

--- a/client/spring-zeebe/src/test/java/io/zeebe/spring/client/bean/value/factory/ReadZeebeDeploymentValueTest.java
+++ b/client/spring-zeebe/src/test/java/io/zeebe/spring/client/bean/value/factory/ReadZeebeDeploymentValueTest.java
@@ -1,0 +1,106 @@
+package io.zeebe.spring.client.bean.value.factory;
+
+import io.zeebe.spring.client.annotation.ZeebeDeployment;
+import io.zeebe.spring.client.bean.ClassInfo;
+import io.zeebe.spring.client.bean.value.ZeebeDeploymentValue;
+import io.zeebe.spring.util.ZeebeExpressionResolver;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+public class ReadZeebeDeploymentValueTest {
+
+  @Mock
+  private ZeebeExpressionResolver expressionResolver;
+
+  private ReadZeebeDeploymentValue readZeebeDeploymentValue;
+
+  @Before
+  public void init() {
+    MockitoAnnotations.initMocks(this);
+    readZeebeDeploymentValue = new ReadZeebeDeploymentValue(expressionResolver);
+  }
+
+  @Test
+  public void shouldReadSingleClassPathResourceTest() {
+    //given
+    ClassInfo classInfo = ClassInfo.builder()
+      .bean(new WithSingleClassPathResource())
+      .build();
+
+    when(expressionResolver.resolve(anyString())).thenAnswer(inv -> inv.getArgument(0));
+
+    ZeebeDeploymentValue expectedDeploymentValue = ZeebeDeploymentValue.builder()
+      .beanInfo(classInfo)
+      .classPathResources(Collections.singletonList("/1.bpmn"))
+      .build();
+
+    //when
+    Optional<ZeebeDeploymentValue> valueForClass = readZeebeDeploymentValue.apply(classInfo);
+
+    //then
+    assertTrue(valueForClass.isPresent());
+    assertEquals(expectedDeploymentValue, valueForClass.get());
+  }
+
+  @Test
+  public void shouldReadMultipleClassPathResourcesTest() {
+    //given
+    ClassInfo classInfo = ClassInfo.builder()
+      .bean(new WithMultipleClassPathResource())
+      .build();
+
+    when(expressionResolver.resolve(anyString())).thenAnswer(inv -> inv.getArgument(0));
+
+    ZeebeDeploymentValue expectedDeploymentValue = ZeebeDeploymentValue.builder()
+      .beanInfo(classInfo)
+      .classPathResources(Arrays.asList("/1.bpmn", "/2.bpmn"))
+      .build();
+
+    //when
+    Optional<ZeebeDeploymentValue> valueForClass = readZeebeDeploymentValue.apply(classInfo);
+
+    //then
+    assertTrue(valueForClass.isPresent());
+    assertEquals(expectedDeploymentValue, valueForClass.get());
+  }
+
+  @Test
+  public void shouldReadNoClassPathResourcesTest() {
+    //given
+    ClassInfo classInfo = ClassInfo.builder()
+      .bean(new WithoutAnnotation())
+      .build();
+
+    when(expressionResolver.resolve(anyString())).thenAnswer(inv -> inv.getArgument(0));
+
+    //when
+    Optional<ZeebeDeploymentValue> valueForClass = readZeebeDeploymentValue.apply(classInfo);
+
+    //then
+    assertFalse(valueForClass.isPresent());
+  }
+
+  @ZeebeDeployment(classPathResources = "/1.bpmn")
+  private static class WithSingleClassPathResource {
+
+  }
+
+  @ZeebeDeployment(classPathResources = {"/1.bpmn", "/2.bpmn"})
+  private static class WithMultipleClassPathResource {
+
+  }
+
+  private static class WithoutAnnotation {
+
+  }
+}

--- a/client/spring-zeebe/src/test/java/io/zeebe/spring/client/config/processor/DeploymentPostProcessorTest.java
+++ b/client/spring-zeebe/src/test/java/io/zeebe/spring/client/config/processor/DeploymentPostProcessorTest.java
@@ -1,0 +1,158 @@
+package io.zeebe.spring.client.config.processor;
+
+import io.zeebe.client.ZeebeClient;
+import io.zeebe.client.api.ZeebeFuture;
+import io.zeebe.client.api.command.DeployWorkflowCommandStep1;
+import io.zeebe.client.api.response.DeploymentEvent;
+import io.zeebe.client.api.response.Workflow;
+import io.zeebe.spring.client.bean.ClassInfo;
+import io.zeebe.spring.client.bean.value.ZeebeDeploymentValue;
+import io.zeebe.spring.client.bean.value.factory.ReadZeebeDeploymentValue;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class DeploymentPostProcessorTest {
+
+  @Mock
+  private ReadZeebeDeploymentValue reader;
+
+  @Mock
+  private ZeebeClient client;
+
+  @Mock
+  private DeployWorkflowCommandStep1 deployStep1;
+
+  @Mock
+  private DeployWorkflowCommandStep1.DeployWorkflowCommandBuilderStep2 deployStep2;
+
+  @Mock
+  private ZeebeFuture<DeploymentEvent> zeebeFuture;
+
+  @Mock
+  private DeploymentEvent deploymentEvent;
+
+  private DeploymentPostProcessor deploymentPostProcessor;
+
+  @Before
+  public void init() {
+    MockitoAnnotations.initMocks(this);
+    deploymentPostProcessor = new DeploymentPostProcessor(reader);
+  }
+
+  @Test
+  public void shouldDeploySingleResourceTest() {
+    //given
+    ClassInfo classInfo = ClassInfo.builder()
+      .build();
+
+    ZeebeDeploymentValue zeebeDeploymentValue = ZeebeDeploymentValue.builder()
+      .classPathResources(Collections.singletonList("/1.bpmn"))
+      .build();
+
+    when(reader.applyOrThrow(classInfo)).thenReturn(zeebeDeploymentValue);
+
+    when(client.newDeployCommand()).thenReturn(deployStep1);
+
+    when(deployStep1.addResourceFromClasspath(anyString())).thenReturn(deployStep2);
+
+    when(deployStep2.send()).thenReturn(zeebeFuture);
+
+    when(zeebeFuture.join()).thenReturn(deploymentEvent);
+
+    when(deploymentEvent.getWorkflows()).thenReturn(Collections.singletonList(getWorkFlow()));
+
+    //when
+    deploymentPostProcessor.apply(classInfo).accept(client);
+
+    //then
+    verify(deployStep1).addResourceFromClasspath(eq("/1.bpmn"));
+    verify(deployStep2).send();
+    verify(zeebeFuture).join();
+  }
+
+  @Test
+  public void shouldDeployMultipleResourcesTest() {
+    //given
+    ClassInfo classInfo = ClassInfo.builder()
+      .build();
+
+    ZeebeDeploymentValue zeebeDeploymentValue = ZeebeDeploymentValue.builder()
+      .classPathResources(Arrays.asList("/1.bpmn", "/2.bpmn"))
+      .build();
+
+    when(reader.applyOrThrow(classInfo)).thenReturn(zeebeDeploymentValue);
+
+    when(client.newDeployCommand()).thenReturn(deployStep1);
+
+    when(deployStep1.addResourceFromClasspath(anyString())).thenReturn(deployStep2);
+
+    when(deployStep2.send()).thenReturn(zeebeFuture);
+
+    when(zeebeFuture.join()).thenReturn(deploymentEvent);
+
+    when(deploymentEvent.getWorkflows()).thenReturn(Collections.singletonList(getWorkFlow()));
+
+    //when
+    deploymentPostProcessor.apply(classInfo).accept(client);
+
+    //then
+    verify(deployStep1).addResourceFromClasspath(eq("/1.bpmn"));
+    verify(deployStep1).addResourceFromClasspath(eq("/2.bpmn"));
+    verify(deployStep2).send();
+    verify(zeebeFuture).join();
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void shouldThrowExceptionOnNoResourcesToDeploy() {
+    //given
+    ClassInfo classInfo = ClassInfo.builder()
+      .build();
+
+    ZeebeDeploymentValue zeebeDeploymentValue = ZeebeDeploymentValue.builder()
+      .classPathResources(Collections.emptyList())
+      .build();
+
+    when(reader.applyOrThrow(classInfo)).thenReturn(zeebeDeploymentValue);
+
+    when(client.newDeployCommand()).thenReturn(deployStep1);
+
+    when(deployStep1.addResourceFromClasspath(anyString())).thenReturn(deployStep2);
+
+    //when
+    deploymentPostProcessor.apply(classInfo).accept(client);
+  }
+
+  private Workflow getWorkFlow() {
+    return new Workflow() {
+      @Override
+      public String getBpmnProcessId() {
+        return "12345-abcd";
+      }
+
+      @Override
+      public int getVersion() {
+        return 1;
+      }
+
+      @Override
+      public long getWorkflowKey() {
+        return 101010;
+      }
+
+      @Override
+      public String getResourceName() {
+        return "TestProcess";
+      }
+    };
+  }
+}

--- a/examples/starter/src/main/java/io/zeebe/spring/example/StarterApplication.java
+++ b/examples/starter/src/main/java/io/zeebe/spring/example/StarterApplication.java
@@ -15,7 +15,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 @SpringBootApplication
 @EnableZeebeClient
 @EnableScheduling
-@ZeebeDeployment(classPathResource = "demoProcess.bpmn")
+@ZeebeDeployment(classPathResources = "demoProcess.bpmn")
 @Slf4j
 public class StarterApplication {
 


### PR DESCRIPTION
Hi
I found possibility of deployment only one resource using `ZeebeDeployment` annotation very limiting, not much to modify and it works with multiple resources. Could be useful also for others, let me know what you think.