### PR TITLE
#81 Update documentation for the Camunda Cloud support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ zeebe.client.security.plaintext=true
 
 For a full set of configuration options please see [ZeebeClientConfigurationProperties.java](blob/master/client/spring-zeebe-starter/src/main/java/io/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java)
 
+## Configuring Camunda Cloud Connection
+
+A connection to the Camunda Cloud is supported out of the box using environment variables.
+Have a look into the [Environment](https://docs.zeebe.io/operations/authorization.html) section in the Zeebe Authorization documentation. 
+
 ## Add Spring Boot Starter to Your Project
 
 Just add the following Maven dependency to your Spring Boot Starter project:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ For a full set of configuration options please see [ZeebeClientConfigurationProp
 
 ## Configuring Camunda Cloud Connection
 
-A connection to the Camunda Cloud is supported out of the box using environment variables.
+Connections to the Camunda Cloud are supported out-of-the-box using environment variables.
 Have a look into the [Environment](https://docs.zeebe.io/operations/authorization.html#environment-variables) section in the Zeebe Authorization documentation. 
 
 ## Add Spring Boot Starter to Your Project

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ For a full set of configuration options please see [ZeebeClientConfigurationProp
 ## Configuring Camunda Cloud Connection
 
 A connection to the Camunda Cloud is supported out of the box using environment variables.
-Have a look into the [Environment](https://docs.zeebe.io/operations/authorization.html) section in the Zeebe Authorization documentation. 
+Have a look into the [Environment](https://docs.zeebe.io/operations/authorization.html#environment-variables) section in the Zeebe Authorization documentation. 
 
 ## Add Spring Boot Starter to Your Project
 


### PR DESCRIPTION
@salaboy I played around with new configuration properties in a branch in my fork: https://github.com/ArtunSubasi/spring-zeebe/tree/security-configuration

Then I found out that the Camunda Cloud connections work out-of-the-box using environment variables. Therefore, I don't think it is a good idea to add an additional support for the application properties. Since the credentials contain confidential information, they must be encrypted or injected using the environment variables anyway.

This PR only contains an update to the documentation.