### PR TITLE
Adds E2E example test for WorkerApplication

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: java
 sudo: false # faster builds
 
+services:
+  - docker
+
 jdk:
 - openjdk8
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,7 +9,7 @@ pipeline {
       cloud getZeebeK8sCloud()
       label getZeebeK8sLabel()
       defaultContainer 'jnlp'
-      yaml libraryResource("zeebe/podspecs/${utils.isProdJenkins() ? 'mavenAgent.yml' : 'mavenAgentStage.yml'}")
+      yaml mavenPodspec([jdk: '8', containerResources: [cpu: '4', memory: '8Gi'], useDind: true])
     }
   }
 

--- a/examples/worker/pom.xml
+++ b/examples/worker/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>io.zeebe.spring.root</groupId>
@@ -15,6 +16,30 @@
     <dependency>
       <groupId>io.zeebe.spring</groupId>
       <artifactId>spring-zeebe-starter</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.zeebe</groupId>
+      <artifactId>zeebe-test-container</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-test</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/examples/worker/src/main/java/io/zeebe/spring/example/WorkerApplication.java
+++ b/examples/worker/src/main/java/io/zeebe/spring/example/WorkerApplication.java
@@ -1,8 +1,9 @@
 package io.zeebe.spring.example;
 
-import io.zeebe.client.api.worker.JobClient;
 import io.zeebe.client.api.response.ActivatedJob;
+import io.zeebe.client.api.worker.JobClient;
 import io.zeebe.spring.client.EnableZeebeClient;
+import io.zeebe.spring.client.annotation.ZeebeDeployment;
 import io.zeebe.spring.client.annotation.ZeebeWorker;
 import java.time.Instant;
 import lombok.extern.slf4j.Slf4j;
@@ -11,6 +12,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 @EnableZeebeClient
+@ZeebeDeployment(classPathResources = "demoProcess.bpmn")
 @Slf4j
 public class WorkerApplication {
 

--- a/examples/worker/src/main/resources/demoProcess.bpmn
+++ b/examples/worker/src/main/resources/demoProcess.bpmn
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:zeebe="http://camunda.org/schema/zeebe/1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_1" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="1.5.0-nightly">
+  <bpmn:process id="demoProcess" isExecutable="true">
+    <bpmn:startEvent id="start" name="start">
+      <bpmn:outgoing>SequenceFlow_1sz6737</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_1sz6737" sourceRef="start" targetRef="taskA" />
+    <bpmn:sequenceFlow id="SequenceFlow_06ytcxw" sourceRef="taskA" targetRef="taskB" />
+    <bpmn:sequenceFlow id="SequenceFlow_1oh45y7" sourceRef="taskB" targetRef="taskC" />
+    <bpmn:endEvent id="end" name="end">
+      <bpmn:incoming>SequenceFlow_148rk2p</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_148rk2p" sourceRef="taskC" targetRef="end" />
+    <bpmn:serviceTask id="taskA" name="task A">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+        <zeebe:ioMapping>
+          <zeebe:input source="=a" target="foo" />
+          <zeebe:output source="=foo" target="bar" />
+        </zeebe:ioMapping>
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1sz6737</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_06ytcxw</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="taskB" name="taks B">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="bar" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_06ytcxw</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1oh45y7</bpmn:outgoing>
+    </bpmn:serviceTask>
+    <bpmn:serviceTask id="taskC" name="taks C">
+      <bpmn:extensionElements>
+        <zeebe:taskDefinition type="foo" />
+      </bpmn:extensionElements>
+      <bpmn:incoming>SequenceFlow_1oh45y7</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_148rk2p</bpmn:outgoing>
+    </bpmn:serviceTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="demoProcess">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="start">
+        <dc:Bounds x="173" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="180" y="138" width="22" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1sz6737_di" bpmnElement="SequenceFlow_1sz6737">
+        <di:waypoint xsi:type="dc:Point" x="209" y="120" />
+        <di:waypoint xsi:type="dc:Point" x="310" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="260" y="105" width="0" height="0" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_06ytcxw_di" bpmnElement="SequenceFlow_06ytcxw">
+        <di:waypoint xsi:type="dc:Point" x="410" y="120" />
+        <di:waypoint xsi:type="dc:Point" x="502" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="456" y="105" width="0" height="0" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1oh45y7_di" bpmnElement="SequenceFlow_1oh45y7">
+        <di:waypoint xsi:type="dc:Point" x="602" y="120" />
+        <di:waypoint xsi:type="dc:Point" x="694" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="648" y="105" width="0" height="0" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0gbv3sc_di" bpmnElement="end">
+        <dc:Bounds x="867" y="102" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="876" y="138" width="18" height="12" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_148rk2p_di" bpmnElement="SequenceFlow_148rk2p">
+        <di:waypoint xsi:type="dc:Point" x="794" y="120" />
+        <di:waypoint xsi:type="dc:Point" x="867" y="120" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="831" y="105" width="0" height="0" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="ServiceTask_09m0goq_di" bpmnElement="taskA">
+        <dc:Bounds x="310" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_0sryj72_di" bpmnElement="taskB">
+        <dc:Bounds x="502" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="ServiceTask_1xu4l3g_di" bpmnElement="taskC">
+        <dc:Bounds x="694" y="80" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/examples/worker/src/test/java/io/zeebe/spring/example/WorkerApplicationTest.java
+++ b/examples/worker/src/test/java/io/zeebe/spring/example/WorkerApplicationTest.java
@@ -1,0 +1,63 @@
+package io.zeebe.spring.example;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.hasEntry;
+
+import io.zeebe.client.ZeebeClient;
+import io.zeebe.client.api.response.WorkflowInstanceResult;
+import io.zeebe.containers.ZeebeContainer;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.ApplicationContextInitializer;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+@ContextConfiguration(initializers = {WorkerApplicationTest.Initializer.class})
+public class WorkerApplicationTest {
+  @ClassRule public static ZeebeContainer zeebeContainer = new ZeebeContainer();
+
+  @Autowired ZeebeClient client;
+
+  @Test
+  public void shouldHandleJobs() {
+    // given
+    final Map<String, Object> variables = new HashMap<>();
+    variables.put("a", 0);
+
+    // when
+    final WorkflowInstanceResult result =
+        client
+            .newCreateInstanceCommand()
+            .bpmnProcessId("demoProcess")
+            .latestVersion()
+            .variables(variables)
+            .withResult()
+            .fetchVariables("foo", "bar")
+            .send()
+            .join();
+
+    // then
+    assertThat(result.getVariablesAsMap(), allOf(hasEntry("foo", 1), hasEntry("bar", 1)));
+  }
+
+  static class Initializer
+      implements ApplicationContextInitializer<ConfigurableApplicationContext> {
+    public void initialize(ConfigurableApplicationContext configurableApplicationContext) {
+      TestPropertyValues.of(
+              "zeebe.client.worker.defaultName=foo-worker",
+              "zeebe.client.broker.contactPoint=" + zeebeContainer.getExternalGatewayAddress(),
+              "zeebe.client.security.plaintext=true")
+          .applyTo(configurableApplicationContext.getEnvironment());
+    }
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,5 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -6,7 +7,7 @@
     <artifactId>camunda-release-parent</artifactId>
     <version>3.3</version>
     <!-- do not remove empty tag - http://jira.codehaus.org/browse/MNG-4687 -->
-    <relativePath />
+    <relativePath/>
   </parent>
 
   <groupId>io.zeebe.spring.root</groupId>
@@ -25,6 +26,7 @@
 
     <zeebe.version>0.26.0</zeebe.version>
     <spring-boot.version>2.2.11.RELEASE</spring-boot.version>
+    <zeebe-test-container.version>2.0.0</zeebe-test-container.version>
 
     <!-- release parent settings for distribution management -->
     <nexus.snapshot.repository>
@@ -119,6 +121,12 @@
         <groupId>com.fasterxml.jackson.module</groupId>
         <artifactId>jackson-module-kotlin</artifactId>
         <version>${kotlin-jackson.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.zeebe</groupId>
+        <artifactId>zeebe-test-container</artifactId>
+        <version>${zeebe-test-container.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
**Description**

This PR adds an example test in the worker example for an E2E test using Testcontainers. It will spin up a Zeebe broker with standalone gateway and wait until it's ready. The worker application is then started and autowired to this container, will deploy its process, and start its workers.

A simple test of creating an instance and waiting for its result is added, which can be expanded to add more complicated tests.

It could be interesting to also add later an example with zeeqs such that users can do more complex verifications (e.g. are my processes deployed? how many processes are running? etc.).

Some notes:

- I wasn't where was the best place to put this, feel free to move this around
- I initially used the configuration as described in the readme, `zeebe.client.broker.gatewayAddress`, but this didn't work. Changing it to the deprecated `zeebe.client.broker.contactPoint` worked however.
- Adding this means adding a development pre-requisite of Docker - to run the test you will need a Docker environment as described [here](https://www.testcontainers.org/supported_docker_environment/)