### PR TITLE
Update to Zeebe 1.1.0

### DIFF
--- a/client/spring-zeebe-starter/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
+++ b/client/spring-zeebe-starter/src/main/java/io/camunda/zeebe/spring/client/properties/ZeebeClientConfigurationProperties.java
@@ -215,6 +215,7 @@ public class ZeebeClientConfigurationProperties implements ZeebeClientProperties
     private String clusterId;
     private String clientId;
     private String clientSecret;
+    private String region = "bru-2";
 
     private String baseUrl = "zeebe.camunda.io";
     private String authUrl = "https://login.cloud.camunda.io/oauth/token";
@@ -243,6 +244,14 @@ public class ZeebeClientConfigurationProperties implements ZeebeClientProperties
 
     public void setClientSecret(String clientSecret) {
       this.clientSecret = clientSecret;
+    }
+
+    public String getRegion() {
+      return region;
+    }
+
+    public void setRegion(final String region) {
+      this.region = region;
     }
 
     public String getBaseUrl() {
@@ -278,7 +287,7 @@ public class ZeebeClientConfigurationProperties implements ZeebeClientProperties
     }
 
     public String getAudience() {
-      return clusterId + "." + baseUrl;
+      return String.format("%s.%s.%s", clusterId, region, baseUrl);
     }
 
     public boolean isConfigured() {
@@ -286,7 +295,7 @@ public class ZeebeClientConfigurationProperties implements ZeebeClientProperties
     }
 
     public String getGatewayAddress() {
-      return clusterId + "." + baseUrl + ":" + port;
+      return String.format("%s.%s.%s:%d", clusterId, region, baseUrl, port);
     }
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <maven.compiler.source>${java.version}</maven.compiler.source>
     <maven.compiler.target>${java.version}</maven.compiler.target>
 
-    <zeebe.version>1.0.0</zeebe.version>
+    <zeebe.version>1.1.0</zeebe.version>
     <spring-boot.version>2.2.11.RELEASE</spring-boot.version>
 
     <!-- release parent settings for distribution management -->


### PR DESCRIPTION
- update Zeebe dependency to 1.1.0
- add region as new configuration property for cloud
- set default region to `bru-2` to be backwards compatible with all post GA clusters